### PR TITLE
Improve Java 21 setup and Maven bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ Verify your installation:
 /Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home/bin/java --version
 ```
 
+Make sure Maven is also using Java 21, not a newer Homebrew JDK:
+
+```sh
+export JAVA_HOME=$(/usr/libexec/java_home -v 21)
+export PATH="$JAVA_HOME/bin:$PATH"
+mvn -version
+```
+
+`mvn -version` should report `Java version: 21...`. If it shows 22+ or 26, the build can fail inside Error Prone even though `java --version` looks fine.
+
 After installing the Temurin JDK, we recommend installing and building `maven`, a package manager for our project:
 
 ```sh
@@ -93,8 +103,17 @@ First, you'll need an IDE (editor). IntelliJ Community Edition is the best free 
 2. Clean and Install the Maven dependencies (from inside `LXStudio-TE` directory):
 
    ```sh
-   mvn clean -U package && mvn install
+   ./mvnw-te.sh clean -U package && ./mvnw-te.sh install
    ```
+
+   If you prefer plain `mvn`, first run:
+
+   ```sh
+   export JAVA_HOME=$(/usr/libexec/java_home -v 21)
+   export PATH="$JAVA_HOME/bin:$PATH"
+   ```
+
+   `./mvnw-te.sh` also bootstraps the archived JogAmp `2.4.0-rc-20230123` jars that this repo expects. Those artifacts are no longer available in normal Maven repositories, so using the helper script avoids a later `gluegen-rt-main` / `jogl-all-main` dependency failure.
 
 3. Open the IntelliJ app. On the initial screen, click Open, and select the `LXStudio-TE` directory you cloned.
 
@@ -106,20 +125,46 @@ First, you'll need an IDE (editor). IntelliJ Community Edition is the best free 
       2. Or, if that JDK is not listed, you can also click the '+' and then select "Add JDK..."
          1. Navigate to `/Library/Java/JavaVirtualMachines/temurin-21.jdk`
          2. Select `temurin-21.jdk`
+      3. If IntelliJ auto-added another SDK such as `26` that points at a Homebrew OpenJDK path, delete it.
+         1. In the left SDK list, click `26`
+         2. Click the `-` button at the top
+         3. Keep `temurin-21`
          
          ![Add JDK from disk](assets/IDE-Setup/AddJDK.png)
 
    2. Project Settings → Project
-      1. Select the Temurin 21 JDK
+      1. Set `SDK` to `temurin-21`
+      2. Set `Language level` to `SDK default` or `21`
+      3. Leave `Compiler output` blank
+      4. Click `Apply`, then `OK`
          ![Project SDK](assets/IDE-Setup/SelectProject.png)
 
-5. Select "Titanic's End" in the top bar (in the dropdown) if you want to use the
+   Quick sanity check:
+
+   - `SDK`: `temurin-21`
+   - `Language level`: `SDK default` or `21`
+   - `Compiler output`: blank
+
+5. Reimport the Maven project inside IntelliJ so the IDE picks up the repo's generated modules, dependencies, and run configuration state.
+
+   1. Open the Maven tool window:
+      1. Look at the right edge of the IntelliJ window for a vertical tab labeled `Maven`
+      2. If you do not see it, use `View → Tool Windows → Maven`
+   2. Click the refresh / reload icon in the Maven panel
+
+   Why this matters:
+
+   - Maven is what tells IntelliJ about the multi-module project layout
+   - it reloads dependencies and generated sources
+   - it helps IntelliJ stay aligned with the same build the command line just used
+
+6. Select "Titanic's End" in the top bar (in the dropdown) if you want to use the
    vehicle model.
    ![Play button](assets/IDE-Setup/PlayButton.png)
 
-6. Hit the green arrow "play" button. (If you just want to build, you can hit the hammer.)
+7. Hit the green arrow "play" button. (If you just want to build, you can hit the hammer.)
 
-7. Assuming things work okay, a UI for Chromatik will pop up: Great! Now, you can play with the buttons.
+8. Assuming things work okay, a UI for Chromatik will pop up: Great! Now, you can play with the buttons.
 
 ### Coding Style
 

--- a/install-jogamp-archive.sh
+++ b/install-jogamp-archive.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERSION="2.4.0-rc-20230123"
+ARCHIVE_URL="https://jogamp.org/deployment/archive/rc/v2.4.0/jar"
+M2_REPO="${HOME}/.m2/repository"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+artifact_installed() {
+  local path="$1"
+  [[ -f "${M2_REPO}/${path}" ]]
+}
+
+download_if_missing() {
+  local url="$1"
+  local dest="$2"
+  if [[ ! -f "${dest}" ]]; then
+    curl -fsSL "$url" -o "$dest"
+  fi
+}
+
+require_cmd curl
+require_cmd mvn
+
+if [[ -z "${JAVA_HOME:-}" ]]; then
+  echo "JAVA_HOME must be set before running install-jogamp-archive.sh." >&2
+  exit 1
+fi
+
+if [[ ! -x "${JAVA_HOME}/bin/jar" ]]; then
+  echo "Could not find the JDK jar tool at ${JAVA_HOME}/bin/jar" >&2
+  exit 1
+fi
+
+if artifact_installed "org/jogamp/gluegen/gluegen-rt-main/${VERSION}/gluegen-rt-main-${VERSION}.pom" \
+  && artifact_installed "org/jogamp/jogl/jogl-all-main/${VERSION}/jogl-all-main-${VERSION}.pom"; then
+  echo "JogAmp archive artifacts already installed for ${VERSION}."
+  exit 0
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "${tmp_dir}"' EXIT
+
+mkdir -p "${tmp_dir}/empty"
+"${JAVA_HOME}/bin/jar" --create --file "${tmp_dir}/empty.jar" -C "${tmp_dir}/empty" .
+
+download_if_missing "${ARCHIVE_URL}/gluegen-rt.jar" "${tmp_dir}/gluegen-rt.jar"
+download_if_missing "${ARCHIVE_URL}/jogl-all.jar" "${tmp_dir}/jogl-all.jar"
+download_if_missing "${ARCHIVE_URL}/gluegen-rt-natives-macosx-universal.jar" "${tmp_dir}/gluegen-rt-natives-macosx-universal.jar"
+download_if_missing "${ARCHIVE_URL}/jogl-all-natives-macosx-universal.jar" "${tmp_dir}/jogl-all-natives-macosx-universal.jar"
+
+cat > "${tmp_dir}/gluegen-rt-main.pom" <<EOF
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.jogamp.gluegen</groupId>
+  <artifactId>gluegen-rt-main</artifactId>
+  <version>${VERSION}</version>
+  <packaging>jar</packaging>
+  <name>GlueGen Runtime (macOS bootstrap)</name>
+  <dependencies>
+    <dependency>
+      <groupId>org.jogamp.gluegen</groupId>
+      <artifactId>gluegen-rt</artifactId>
+      <version>${VERSION}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jogamp.gluegen</groupId>
+      <artifactId>gluegen-rt</artifactId>
+      <version>${VERSION}</version>
+      <classifier>natives-macosx-universal</classifier>
+    </dependency>
+  </dependencies>
+</project>
+EOF
+
+cat > "${tmp_dir}/jogl-all-main.pom" <<EOF
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.jogamp.jogl</groupId>
+  <artifactId>jogl-all-main</artifactId>
+  <version>${VERSION}</version>
+  <packaging>jar</packaging>
+  <name>JOGL All (macOS bootstrap)</name>
+  <dependencies>
+    <dependency>
+      <groupId>org.jogamp.jogl</groupId>
+      <artifactId>jogl-all</artifactId>
+      <version>${VERSION}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jogamp.jogl</groupId>
+      <artifactId>jogl-all</artifactId>
+      <version>${VERSION}</version>
+      <classifier>natives-macosx-universal</classifier>
+    </dependency>
+  </dependencies>
+</project>
+EOF
+
+mvn install:install-file -Dfile="${tmp_dir}/gluegen-rt.jar" -DgroupId=org.jogamp.gluegen -DartifactId=gluegen-rt -Dversion="${VERSION}" -Dpackaging=jar
+mvn install:install-file -Dfile="${tmp_dir}/gluegen-rt-natives-macosx-universal.jar" -DgroupId=org.jogamp.gluegen -DartifactId=gluegen-rt -Dversion="${VERSION}" -Dpackaging=jar -Dclassifier=natives-macosx-universal
+mvn install:install-file -Dfile="${tmp_dir}/jogl-all.jar" -DgroupId=org.jogamp.jogl -DartifactId=jogl-all -Dversion="${VERSION}" -Dpackaging=jar
+mvn install:install-file -Dfile="${tmp_dir}/jogl-all-natives-macosx-universal.jar" -DgroupId=org.jogamp.jogl -DartifactId=jogl-all -Dversion="${VERSION}" -Dpackaging=jar -Dclassifier=natives-macosx-universal
+
+mvn install:install-file -Dfile="${tmp_dir}/empty.jar" -DpomFile="${tmp_dir}/gluegen-rt-main.pom"
+mvn install:install-file -Dfile="${tmp_dir}/empty.jar" -DpomFile="${tmp_dir}/jogl-all-main.pom"
+
+echo "Installed JogAmp archive artifacts for ${VERSION} into ${M2_REPO}."

--- a/mvnw-te.sh
+++ b/mvnw-te.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "${OSTYPE:-}" != darwin* ]]; then
+  echo "mvnw-te.sh is intended for macOS. Please run Maven with Java 21." >&2
+  exec mvn "$@"
+fi
+
+if ! command -v /usr/libexec/java_home >/dev/null 2>&1; then
+  echo "Could not find /usr/libexec/java_home. Please install Temurin 21 and set JAVA_HOME manually." >&2
+  exit 1
+fi
+
+JAVA21_HOME="$(/usr/libexec/java_home -v 21 2>/dev/null || true)"
+
+if [[ -z "${JAVA21_HOME}" ]]; then
+  echo "Temurin/OpenJDK 21 was not found. Install it first, for example with: brew install temurin@21" >&2
+  exit 1
+fi
+
+export JAVA_HOME="${JAVA21_HOME}"
+export PATH="${JAVA_HOME}/bin:${PATH}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+M2_REPO="${HOME}/.m2/repository"
+
+if [[ ! -f "${M2_REPO}/org/jogamp/gluegen/gluegen-rt-main/2.4.0-rc-20230123/gluegen-rt-main-2.4.0-rc-20230123.pom" ]] \
+  || [[ ! -f "${M2_REPO}/org/jogamp/jogl/jogl-all-main/2.4.0-rc-20230123/jogl-all-main-2.4.0-rc-20230123.pom" ]]; then
+  "${SCRIPT_DIR}/install-jogamp-archive.sh"
+fi
+
+exec mvn "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -112,25 +112,6 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-enforcer-plugin</artifactId>
 					<version>${maven-enforcer-plugin.version}</version>
-					<executions>
-						<execution>
-							<id>enforce-maven</id>
-							<goals>
-								<goal>enforce</goal>
-							</goals>
-							<configuration>
-								<rules>
-									<requireMavenVersion>
-										<version>3.3.1</version> <!-- Specify your minimum Maven version here -->
-										<message>Maven version 3.3.1 or higher is required to use
-											${maven.multiModuleProjectDirectory} property
-										</message>
-									</requireMavenVersion>
-								</rules>
-								<fail>true</fail>
-							</configuration>
-						</execution>
-					</executions>
 				</plugin>
 				<plugin>
 					<groupId>com.diffplug.spotless</groupId>
@@ -146,6 +127,41 @@
 				</plugin>
 			</plugins>
 		</pluginManagement>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>${maven-enforcer-plugin.version}</version>
+				<executions>
+					<execution>
+						<id>enforce-build-environment</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<requireMavenVersion>
+									<version>3.3.1</version>
+									<message>Maven version 3.3.1 or higher is required to use
+										${maven.multiModuleProjectDirectory} property
+									</message>
+								</requireMavenVersion>
+								<requireJavaVersion>
+									<version>[21,22)</version>
+									<message>
+										This project must be built with Java 21. Newer JDKs can cause Error Prone
+										to crash during compilation. On macOS, run
+										./mvnw-te.sh ... or export JAVA_HOME=$(/usr/libexec/java_home -v 21)
+										before invoking Maven.
+									</message>
+								</requireJavaVersion>
+							</rules>
+							<fail>true</fail>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
 		<resources>
 			<resource>
 				<directory>src/main/resources</directory>


### PR DESCRIPTION
## Summary
- document the working IntelliJ Java 21 project setup
- enforce Java 21 in Maven to fail fast on wrong JDKs
- add helper scripts to bootstrap archived JogAmp dependencies and run Maven consistently on macOS

## Testing
- ./mvnw-te.sh clean -U package
- ./mvnw-te.sh -pl te-app -am compile