### PR TITLE
Add overlay channel blend mode

### DIFF
--- a/te-app/src/main/java/heronarts/lx/studio/TEApp.java
+++ b/te-app/src/main/java/heronarts/lx/studio/TEApp.java
@@ -91,6 +91,7 @@ import titanicsend.lx.DirectorAPCminiMk2;
 import titanicsend.lx.EffectsMiniLab3;
 import titanicsend.model.TEWholeModel;
 import titanicsend.model.TEWholeModelDynamic;
+import titanicsend.lx.blend.OverlayBlend;
 import titanicsend.modulator.dmx.Dmx16bitModulator;
 import titanicsend.modulator.dmx.DmxDirectorColorModulator;
 import titanicsend.modulator.dmx.DmxDualRangeModulator;
@@ -403,7 +404,10 @@ public class TEApp extends LXStudio {
       lx.registry.addPattern(SketchStem.class);
 
       // Arta's custom patterns
+      lx.registry.addChannelBlend(OverlayBlend.class);
       lx.registry.addPattern(titanicsend.pattern.arta.PacmanPattern.class);
+      lx.registry.addPattern(titanicsend.pattern.arta.MissPacmanPattern.class);
+      lx.registry.addPattern(titanicsend.pattern.arta.PacmanItemsPattern.class);
       lx.registry.addPattern(titanicsend.pattern.arta.GhostPattern.class);
       lx.registry.addPattern(titanicsend.pattern.arta.ScaredGhostPattern.class);
       lx.registry.addPattern(titanicsend.pattern.arta.EyePattern.class);

--- a/te-app/src/main/java/titanicsend/lx/blend/OverlayBlend.java
+++ b/te-app/src/main/java/titanicsend/lx/blend/OverlayBlend.java
@@ -1,0 +1,46 @@
+package titanicsend.lx.blend;
+
+import heronarts.lx.LX;
+import heronarts.lx.blend.LXBlend;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.model.LXModel;
+import heronarts.lx.model.LXPoint;
+
+/**
+ * Overlay blend for sprite-style compositing.
+ *
+ * <p>Non-black pixels from the source buffer sit on top of the destination.
+ * Black pixels in the source are treated as empty and allow the lower layer to
+ * show through. Channel alpha is still respected so the fader behaves
+ * normally.</p>
+ */
+public class OverlayBlend extends LXBlend {
+
+  public OverlayBlend(LX lx) {
+    super(lx);
+    setName("Overlay");
+  }
+
+  @Override
+  public void blend(int[] dst, int[] src, double alpha, int[] output, LXModel model) {
+    int alphaMask = (int) (alpha * LXColor.BLEND_ALPHA_FULL);
+    for (LXPoint p : model.points) {
+      output[p.index] = overlay(dst[p.index], src[p.index], alphaMask);
+    }
+  }
+
+  @Override
+  public void blend(int[] dst, int[] src, double alpha, int[] output, int start, int num) {
+    int alphaMask = (int) (alpha * LXColor.BLEND_ALPHA_FULL);
+    for (int i = start; i < start + num; ++i) {
+      output[i] = overlay(dst[i], src[i], alphaMask);
+    }
+  }
+
+  private static int overlay(int dst, int src, int alphaMask) {
+    if ((src & LXColor.RGB_MASK) == 0) {
+      return dst;
+    }
+    return LXColor.lerp(dst, src, alphaMask);
+  }
+}


### PR DESCRIPTION
## Summary
- add a new global Overlay channel blend mode
- let non-black pixels from the top channel sit above lower channels
- register the blend so it appears in the standard channel blend dropdown

## Testing
- built successfully in the main working repo with: ./mvnw-te.sh -pl te-app -am compile
- isolated worktree mvn runs hit an existing Error Prone crash in audio-stems, unrelated to this diff
