### PR TITLE
Add PacmanV2 shader pattern

### DIFF
--- a/te-app/resources/shaders/pacman_v2.fs
+++ b/te-app/resources/shaders/pacman_v2.fs
@@ -1,0 +1,55 @@
+#define TE_ALPHATHRESHOLD 0.96
+
+const float PI = 3.14159265359;
+const float TAU = 6.28318530718;
+
+uniform float mouthSize;
+uniform float mouthOpen;
+uniform bool showEye;
+uniform float eyeSize;
+uniform vec2 eyeOffset;
+uniform bool faceRight;
+uniform float edgeFeather;
+
+float circleMask(vec2 p, float radius, float feather) {
+    return smoothstep(radius + feather, radius - feather, length(p));
+}
+
+float angleDiff(float a, float b) {
+    float d = abs(a - b);
+    return min(d, TAU - d);
+}
+
+void mainImage(out vec4 fragColor, in vec2 fragCoord) {
+    vec2 uv = fragCoord / iResolution.xy;
+    vec2 p = uv - 0.5;
+    p.x *= iResolution.x / iResolution.y;
+
+    float radius = 0.48 * iScale;
+    float feather = max(edgeFeather * 0.35, 0.0006);
+    float cutoutFeather = max(edgeFeather * 0.08, 0.00025);
+
+    float bodyMask = circleMask(p, radius, feather);
+
+    float facing = faceRight ? 0.0 : PI;
+    float mouthHalfAngle = mouthSize * PI * mouthOpen;
+    float angle = atan(p.y, p.x);
+    float mouthAngle = angleDiff(angle, facing);
+    float mouthAngularFeather = 0.012 + cutoutFeather * 1.2;
+    float mouthMask =
+        smoothstep(mouthHalfAngle + mouthAngularFeather, mouthHalfAngle - mouthAngularFeather, mouthAngle)
+        * bodyMask;
+
+    float finalMask = bodyMask * (1.0 - mouthMask);
+
+    if (showEye) {
+        vec2 eyeCenter = vec2((faceRight ? -1.0 : 1.0) * eyeOffset.x * radius, eyeOffset.y * radius);
+        float eyeRadius = eyeSize * radius;
+        float eyeMask = circleMask(p - eyeCenter, eyeRadius, cutoutFeather);
+        finalMask *= (1.0 - eyeMask);
+    }
+
+    finalMask = clamp(finalMask, 0.0, 1.0);
+
+    fragColor = vec4(iColorRGB, finalMask);
+}

--- a/te-app/src/main/java/heronarts/lx/studio/TEApp.java
+++ b/te-app/src/main/java/heronarts/lx/studio/TEApp.java
@@ -407,6 +407,7 @@ public class TEApp extends LXStudio {
       lx.registry.addChannelBlend(OverlayBlend.class);
       lx.registry.addPattern(titanicsend.pattern.arta.PacmanColorCalibratorPattern.class);
       lx.registry.addPattern(titanicsend.pattern.arta.PacmanPattern.class);
+      lx.registry.addPattern(titanicsend.pattern.arta.v2.PacmanV2Pattern.class);
       lx.registry.addPattern(titanicsend.pattern.arta.MissPacmanPattern.class);
       lx.registry.addPattern(titanicsend.pattern.arta.PacmanChasePattern.class);
       lx.registry.addPattern(titanicsend.pattern.arta.PacmanItemsPattern.class);

--- a/te-app/src/main/java/titanicsend/pattern/arta/v2/PacmanV2Pattern.java
+++ b/te-app/src/main/java/titanicsend/pattern/arta/v2/PacmanV2Pattern.java
@@ -1,0 +1,128 @@
+package titanicsend.pattern.arta.v2;
+
+import heronarts.lx.LX;
+import heronarts.lx.LXCategory;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.parameter.BooleanParameter;
+import heronarts.lx.parameter.CompoundParameter;
+import titanicsend.color.TEColorParameter;
+import titanicsend.pattern.glengine.GLShader;
+import titanicsend.pattern.glengine.GLShaderPattern;
+import titanicsend.pattern.jon.TEControlTag;
+import titanicsend.pattern.yoffa.framework.TEShaderView;
+import titanicsend.util.TEColor;
+
+@LXCategory("Arta")
+public class PacmanV2Pattern extends GLShaderPattern {
+  public final CompoundParameter edgeFeather =
+      new CompoundParameter("Edge", 0.0035f, 0.0005f, 0.02f)
+          .setDescription("Softness of Pacman's circle edge");
+
+  public final CompoundParameter mouthSize =
+      new CompoundParameter("MSize", 0.48f, 0.1f, 0.8f)
+          .setDescription("Size of Pacman's mouth");
+
+  public final CompoundParameter mouthAnimation =
+      new CompoundParameter("MAnim", 0.62f, 0.0f, 1.0f)
+          .setDescription("Mouth animation amount");
+
+  public final CompoundParameter mouthSpeed =
+      new CompoundParameter("MSpeed", 1.55f, 0.1f, 6.0f)
+          .setDescription("Speed of mouth animation");
+
+  public final BooleanParameter mouthMove =
+      new BooleanParameter("MouthMove", true)
+          .setDescription("Enable mouth movement");
+
+  public final BooleanParameter showEye =
+      new BooleanParameter("Eyes", true).setDescription("Show Pacman's eye");
+
+  public final CompoundParameter eyeSize =
+      new CompoundParameter("EyeSize", 0.13f, 0.05f, 0.3f)
+          .setDescription("Size of Pacman's eye");
+
+  public final CompoundParameter eyeX =
+      new CompoundParameter("EyeX", 0.1f, -0.5f, 0.5f)
+          .setDescription("Horizontal eye offset");
+
+  public final CompoundParameter eyeY =
+      new CompoundParameter("EyeY", 0.4f, -0.5f, 0.5f)
+          .setDescription("Vertical eye offset");
+
+  public final BooleanParameter faceRight =
+      new BooleanParameter("FaceRig", true).setDescription("Face right");
+
+  public final BooleanParameter colorCycle =
+      new BooleanParameter("ColorCy", false).setDescription("Cycle TE color over time");
+
+  public final CompoundParameter colorCycleSpeed =
+      new CompoundParameter("ColorSp", 0.12f, 0.01f, 0.75f)
+          .setDescription("Speed of TE color cycling");
+
+  public PacmanV2Pattern(LX lx) {
+    super(lx, TEShaderView.ALL_POINTS);
+
+    controls.setLabel(TEControlTag.SIZE, "PSize");
+    controls.setRange(TEControlTag.SIZE, 0.92, 0.35, 1.15);
+
+    controls.markUnused(controls.getLXControl(TEControlTag.LEVELREACTIVITY));
+    controls.markUnused(controls.getLXControl(TEControlTag.FREQREACTIVITY));
+    controls.markUnused(controls.getLXControl(TEControlTag.SPEED));
+    controls.markUnused(controls.getLXControl(TEControlTag.XPOS));
+    controls.markUnused(controls.getLXControl(TEControlTag.YPOS));
+    controls.markUnused(controls.getLXControl(TEControlTag.QUANTITY));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOW1));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOW2));
+    controls.markUnused(controls.getLXControl(TEControlTag.WOWTRIGGER));
+
+    addCommonControls();
+
+    this.controls.color.colorSource.setValue(TEColorParameter.ColorSource.STATIC);
+    this.controls.color.hue.setValue(LXColor.h(TEColor.YELLOW));
+    this.controls.color.saturation.setValue(100);
+    this.controls.color.brightness.setValue(100);
+
+    addParameter("Edge", this.edgeFeather);
+    addParameter("MSize", this.mouthSize);
+    addParameter("MAnim", this.mouthAnimation);
+    addParameter("MSpeed", this.mouthSpeed);
+    addParameter("MouthMove", this.mouthMove);
+    addParameter("Eyes", this.showEye);
+    addParameter("EyeSize", this.eyeSize);
+    addParameter("EyeX", this.eyeX);
+    addParameter("EyeY", this.eyeY);
+    addParameter("FaceRig", this.faceRight);
+    addParameter("ColorCy", this.colorCycle);
+    addParameter("ColorSp", this.colorCycleSpeed);
+
+    addShader(
+        GLShader.config(lx).withFilename("pacman_v2.fs").withUniformSource(this::setUniforms));
+  }
+
+  @Override
+  public void runTEAudioPattern(double deltaMs) {
+    if (this.colorCycle.isOn()) {
+      double delta = deltaMs * 0.001 * this.colorCycleSpeed.getValue();
+      this.controls.color.offset.incrementNormalized(delta, true);
+    }
+    super.runTEAudioPattern(deltaMs);
+  }
+
+  private void setUniforms(GLShader shader) {
+    shader.setUniform("edgeFeather", this.edgeFeather.getValuef());
+    shader.setUniform("mouthSize", this.mouthSize.getValuef());
+    shader.setUniform("mouthOpen", computeMouthOpen());
+    shader.setUniform("showEye", this.showEye.isOn());
+    shader.setUniform("eyeSize", this.eyeSize.getValuef());
+    shader.setUniform("eyeOffset", this.eyeX.getValuef(), this.eyeY.getValuef());
+    shader.setUniform("faceRight", this.faceRight.isOn());
+  }
+
+  private float computeMouthOpen() {
+    if (!this.mouthMove.isOn()) {
+      return 1f;
+    }
+    float wave = (float) ((Math.sin(getTime() * this.mouthSpeed.getValue() * Math.PI * 2) + 1) * 0.5);
+    return (0.2f + 0.8f * wave) * this.mouthAnimation.getValuef();
+  }
+}


### PR DESCRIPTION
## Summary
- add shader-backed `PacmanV2Pattern`
- add `pacman_v2.fs` shader for body, mouth, and eye rendering
- register `PacmanV2Pattern` in `TEApp` so it appears in LXStudio

## Notes
- this PR only includes the PacmanV2 pattern files plus the one registration line needed for visibility
- no framework, blend, or engine behavior changes are included

## Testing
- `./mvnw-te.sh -q -DskipTests compile`