### PR TITLE
Set Pacman project frame rate to 60 FPS

### DIFF
--- a/te-app/Projects/BM2024_Pacman.lxp
+++ b/te-app/Projects/BM2024_Pacman.lxp
@@ -11076,7 +11076,7 @@
       "label": "Engine",
       "compositorMultithreaded": false,
       "networkMultithreaded": false,
-      "framesPerSecond": 40.0,
+      "framesPerSecond": 60.0,
       "speed": 1.0,
       "performanceMode": false,
       "camera-1": false,


### PR DESCRIPTION
## Summary
- Updates `BM2024_Pacman.lxp` engine `framesPerSecond` from 40 FPS to 60 FPS
- Matches the main Titanic's End project frame rate
- Leaves Art-Net/output FPS unchanged at uncapped/default behavior

## Testing
- Parsed `BM2024_Pacman.lxp` as JSON and verified `framesPerSecond` is `60.0`
- Confirmed PR branch diff contains only `te-app/Projects/BM2024_Pacman.lxp`
