### PR TITLE
Add JP-Mini Pacman MIDI surface

### DIFF
--- a/te-app/src/main/java/heronarts/lx/studio/TEApp.java
+++ b/te-app/src/main/java/heronarts/lx/studio/TEApp.java
@@ -89,6 +89,8 @@ import titanicsend.lx.APC40Mk2.UserButton;
 import titanicsend.lx.APCminiMk2;
 import titanicsend.lx.DirectorAPCminiMk2;
 import titanicsend.lx.EffectsMiniLab3;
+import titanicsend.lx.JPMini;
+import titanicsend.midi.MidiNames;
 import titanicsend.model.TEWholeModel;
 import titanicsend.model.TEWholeModelDynamic;
 import titanicsend.lx.blend.OverlayBlend;
@@ -510,6 +512,8 @@ public class TEApp extends LXStudio {
       // Midi surface names for use with BomeBox
       lx.engine.midi.registerSurface(APC40Mk2.class);
       lx.engine.midi.registerSurface(APCminiMk2.class);
+      lx.engine.midi.registerSurface(JPMini.class);
+      lx.engine.midi.registerSurface(MidiNames.JPMINI_BLUETOOTH, JPMini.class);
       // The Director midi surface must be registered *after* the Director and ColorPaletteManager
       lx.engine.midi.registerSurface(DirectorAPCminiMk2.class);
       lx.engine.midi.registerSurface(EffectsMiniLab3.class);

--- a/te-app/src/main/java/titanicsend/lx/JPMini.java
+++ b/te-app/src/main/java/titanicsend/lx/JPMini.java
@@ -1,0 +1,129 @@
+package titanicsend.lx;
+
+import heronarts.lx.LX;
+import heronarts.lx.midi.LXMidiInput;
+import heronarts.lx.midi.LXMidiOutput;
+import heronarts.lx.midi.MidiAftertouch;
+import heronarts.lx.midi.MidiControlChange;
+import heronarts.lx.midi.MidiNote;
+import heronarts.lx.midi.MidiNoteOn;
+import heronarts.lx.midi.surface.LXMidiSurface;
+import heronarts.lx.mixer.LXAbstractChannel;
+import heronarts.lx.mixer.LXChannel;
+import heronarts.lx.pattern.LXPattern;
+import titanicsend.midi.MidiNames;
+import titanicsend.util.TE;
+
+/**
+ * JP-MINI Bluetooth MIDI surface.
+ *
+ * <p>The 4x4 pad grid selects patterns on the Pacman channel. Pressing a pad solos the Pacman
+ * channel by raising its fader and pulling the other channel faders down.
+ */
+@LXMidiSurface.Name("JP-Mini Pacman")
+@LXMidiSurface.DeviceName(MidiNames.JPMINI)
+public class JPMini extends LXMidiSurface {
+
+  private static final String PACMAN_CHANNEL_LABEL = "Pacman";
+
+  public JPMini(LX lx, LXMidiInput input, LXMidiOutput output) {
+    super(lx, input, output);
+    TE.log("JP-Mini surface initialized");
+  }
+
+  @Override
+  protected void onEnable(boolean on) {
+    TE.log("JP-Mini surface " + (on ? "enabled" : "disabled"));
+  }
+
+  @Override
+  protected void onReconnect() {
+    TE.log("JP-Mini surface reconnected");
+  }
+
+  @Override
+  public void noteOnReceived(MidiNoteOn note) {
+    int pitch = note.getPitch();
+    if (pitch >= 1 && pitch <= 16 && note.getVelocity() > 0) {
+      selectPacmanPattern(pitch - 1);
+      return;
+    }
+
+    TE.log(
+        "JP-Mini note on channel="
+            + note.getChannel()
+            + " pitch="
+            + note.getPitch()
+            + " velocity="
+            + note.getVelocity());
+  }
+
+  private void selectPacmanPattern(int patternIndex) {
+    LXChannel pacmanChannel = findPacmanChannel();
+    if (pacmanChannel == null) {
+      TE.log("JP-Mini could not find channel named " + PACMAN_CHANNEL_LABEL);
+      return;
+    }
+
+    soloPacmanChannel(pacmanChannel);
+
+    if (patternIndex >= pacmanChannel.patterns.size()) {
+      TE.log(
+          "JP-Mini pad "
+              + (patternIndex + 1)
+              + " has no Pacman pattern; channel only has "
+              + pacmanChannel.patterns.size());
+      return;
+    }
+
+    LXPattern pattern = pacmanChannel.patterns.get(patternIndex);
+    pacmanChannel.goPatternIndex(patternIndex);
+    TE.log("JP-Mini selected Pacman pattern " + (patternIndex + 1) + ": " + pattern.getLabel());
+  }
+
+  private LXChannel findPacmanChannel() {
+    for (LXAbstractChannel channel : this.lx.engine.mixer.channels) {
+      if (channel instanceof LXChannel && PACMAN_CHANNEL_LABEL.equals(channel.getLabel())) {
+        return (LXChannel) channel;
+      }
+    }
+    return null;
+  }
+
+  private void soloPacmanChannel(LXChannel pacmanChannel) {
+    for (LXAbstractChannel channel : this.lx.engine.mixer.channels) {
+      channel.fader.setValue(channel == pacmanChannel ? 1 : 0);
+    }
+  }
+
+  @Override
+  public void noteOffReceived(MidiNote note) {
+    TE.log(
+        "JP-Mini note off channel="
+            + note.getChannel()
+            + " pitch="
+            + note.getPitch()
+            + " velocity="
+            + note.getVelocity());
+  }
+
+  @Override
+  public void controlChangeReceived(MidiControlChange cc) {
+    TE.log(
+        "JP-Mini CC channel="
+            + cc.getChannel()
+            + " cc="
+            + cc.getCC()
+            + " value="
+            + cc.getValue());
+  }
+
+  @Override
+  public void aftertouchReceived(MidiAftertouch aftertouch) {
+    TE.log(
+        "JP-Mini aftertouch channel="
+            + aftertouch.getChannel()
+            + " pressure="
+            + aftertouch.getAftertouch());
+  }
+}

--- a/te-app/src/main/java/titanicsend/midi/MidiNames.java
+++ b/te-app/src/main/java/titanicsend/midi/MidiNames.java
@@ -31,4 +31,8 @@ public class MidiNames {
   public static final String BOMEBOX_MIDIFIGHTERTWISTER2 = BOMEBOX + "Midi Fighter Twister (2)";
   public static final String BOMEBOX_MIDIFIGHTERTWISTER3 = BOMEBOX + "Midi Fighter Twister (3)";
   public static final String BOMEBOX_MIDIFIGHTERTWISTER4 = BOMEBOX + "Midi Fighter Twister (4)";
+
+  // JP-MINI Bluetooth MIDI controller. CoreMIDI and Java may expose this differently.
+  public static final String JPMINI = "JP-Mini";
+  public static final String JPMINI_BLUETOOTH = "Bluetooth";
 }


### PR DESCRIPTION
## Summary
- add a JP-Mini MIDI surface for the Bluetooth pad controller
- map pads 1-16 to Pacman channel pattern slots
- solo the Pacman channel when selecting a pattern
- register the surface for both JP-Mini and Bluetooth CoreMIDI names

## Test
- ./mvnw-te.sh -pl te-app -am -DskipTests package