### PR TITLE
Tune Miss Pacman animation

### DIFF
--- a/te-app/Projects/BM2024_Pacman.lxp
+++ b/te-app/Projects/BM2024_Pacman.lxp
@@ -13605,6 +13605,65 @@
                 "defaults": {}
               },
               {
+                "id": 472156695,
+                "class": "titanicsend.pattern.arta.MissPacmanPattern",
+                "internal": {
+                  "modulationColor": 0,
+                  "modulationControlsExpanded": true,
+                  "modulationsExpanded": true,
+                  "expanded": true,
+                  "expandedCue": true,
+                  "expandedAux": true,
+                  "modulationExpanded": false
+                },
+                "parameters": {
+                  "label": "MissPacman",
+                  "midiFilter/enabled": true,
+                  "midiFilter/channel": 16,
+                  "midiFilter/channel/name": "OMNI",
+                  "midiFilter/minNote": 0,
+                  "midiFilter/noteRange": 128,
+                  "midiFilter/minVelocity": 1,
+                  "midiFilter/velocityRange": 127,
+                  "view": 0,
+                  "viewPriority": 0,
+                  "enabled": true,
+                  "recall": false,
+                  "launch": false,
+                  "compositeBlend": 0,
+                  "compositeLevel": 1.0,
+                  "hasCustomCycleTime": false,
+                  "customCycleTimeSecs": 60.0,
+                  "autoMute": false,
+                  "cueActive": false,
+                  "auxActive": false,
+                  "setDefaults": false,
+                  "Size": 0.949999988079071,
+                  "compositeMode": 0
+                },
+                "children": {
+                  "modulation": {
+                    "id": 472156696,
+                    "class": "heronarts.lx.modulation.LXModulationEngine",
+                    "internal": {
+                      "modulationColor": 0,
+                      "modulationControlsExpanded": true,
+                      "modulationsExpanded": true
+                    },
+                    "parameters": {
+                      "label": "Modulation"
+                    },
+                    "children": {},
+                    "modulators": [],
+                    "modulations": [],
+                    "triggers": []
+                  }
+                },
+                "deviceVersion": -1,
+                "effects": [],
+                "defaults": {}
+              },
+              {
                 "id": 472137975,
                 "class": "titanicsend.pattern.arta.EyePattern",
                 "internal": {

--- a/te-app/src/main/java/titanicsend/pattern/arta/MissPacmanPattern.java
+++ b/te-app/src/main/java/titanicsend/pattern/arta/MissPacmanPattern.java
@@ -16,7 +16,7 @@ public class MissPacmanPattern extends TEAudioPattern {
 
     private static final int GRID_WIDTH = 16;
     private static final int GRID_HEIGHT = 16;
-    private static final double FRAME_MS = 100.0;
+    private static final double FRAME_MS = 165.0;
 
     // Reverse-engineered from the actual GIF frames at:
     // https://media.tenor.com/5IjXWp2X39QAAAAj/pac-man-pac-man.gif


### PR DESCRIPTION
## Summary
- Slow the Miss Pacman mouth animation from 100ms to 165ms per frame.
- Add MissPacman to the Pacman channel pattern list in the saved project.

## Why
The original Miss Pacman animation was moving too fast in Chromatik and felt frantic. This keeps the same pixel frames while making the motion easier to read on the car.

## Verification
- Ran `./mvnw-te.sh -q -DskipTests package` successfully.
- Checked the project-file diff and kept only the MissPacman pattern insertion.
