### PR TITLE
Increase PacmanV2 mouth cutout

### DIFF
--- a/te-app/resources/shaders/pacman_v2.fs
+++ b/te-app/resources/shaders/pacman_v2.fs
@@ -36,9 +36,11 @@ void mainImage(out vec4 fragColor, in vec2 fragCoord) {
     float angle = atan(p.y, p.x);
     float mouthAngle = angleDiff(angle, facing);
     float mouthAngularFeather = 0.012 + cutoutFeather * 1.2;
+    float mouthOvercut = max(feather * 10.0, 0.018);
+    float mouthRadialMask = circleMask(p, radius + mouthOvercut, cutoutFeather);
     float mouthMask =
         smoothstep(mouthHalfAngle + mouthAngularFeather, mouthHalfAngle - mouthAngularFeather, mouthAngle)
-        * bodyMask;
+        * mouthRadialMask;
 
     float finalMask = bodyMask * (1.0 - mouthMask);
 


### PR DESCRIPTION
## Summary
- Extend the PacmanV2 mouth cutout slightly beyond the body radius
- Prevent the soft body edge from leaving a yellow rim/lip at the mouth boundary under diffusion

## Verification
- ./mvnw-te.sh -q -DskipTests package

Scope: shader-only PacmanV2 mouth fix; pixelated Pac-Man WIP was stashed and is not included.