### PR TITLE
Add JP-Mini green bank autoplay controls

### DIFF
--- a/te-app/src/main/java/titanicsend/lx/JPMini.java
+++ b/te-app/src/main/java/titanicsend/lx/JPMini.java
@@ -21,20 +21,25 @@ import titanicsend.util.TE;
 /**
  * JP-MINI Bluetooth MIDI surface.
  *
- * <p>The 4x4 pad grid selects patterns on the Pacman channel. Pressing a pad raises the Pacman
- * channel fader without muting other channels, so Pacman patterns can be layered.
+ * <p>The JP-Mini banks select patterns on matching Chromatik channels. Pressing a pad raises that
+ * channel fader without muting other channels, so patterns can be layered. The top buttons control
+ * whichever JP-Mini bank/channel was most recently selected.
  */
 @LXMidiSurface.Name("JP-Mini Pacman")
 @LXMidiSurface.DeviceName(MidiNames.JPMINI)
 public class JPMini extends LXMidiSurface {
 
   private static final String PACMAN_CHANNEL_LABEL = "Pacman";
+  private static final String AUTOPLAY_CHANNEL_LABEL = "Autoplay";
+  private static final int GREEN_BANK_CHANNEL = 9;
   private static final int TOP_BUTTON_CHANNEL = 0;
   private static final int AUTOPLAY_ON_CC = 22;
   private static final int AUTOPLAY_OFF_CC = 23;
-  private static final int SOLO_PACMAN_CC = 24;
+  private static final int SOLO_ACTIVE_CHANNEL_CC = 24;
   private static final int TOP_BUTTON_TRIGGER_VALUE = 127;
   private static final double AUTOPLAY_INTERVAL_SECONDS = 30;
+
+  private String activeChannelLabel = PACMAN_CHANNEL_LABEL;
 
   public JPMini(LX lx, LXMidiInput input, LXMidiOutput output) {
     super(lx, input, output);
@@ -53,12 +58,6 @@ public class JPMini extends LXMidiSurface {
 
   @Override
   public void noteOnReceived(MidiNoteOn note) {
-    int pitch = note.getPitch();
-    if (pitch >= 1 && pitch <= 16 && note.getVelocity() > 0) {
-      selectPacmanPattern(pitch - 1);
-      return;
-    }
-
     TE.log(
         "JP-Mini note on channel="
             + note.getChannel()
@@ -66,34 +65,70 @@ public class JPMini extends LXMidiSurface {
             + note.getPitch()
             + " velocity="
             + note.getVelocity());
-  }
 
-  private void selectPacmanPattern(int patternIndex) {
-    LXChannel pacmanChannel = findPacmanChannel();
-    if (pacmanChannel == null) {
-      TE.log("JP-Mini could not find channel named " + PACMAN_CHANNEL_LABEL);
+    int pitch = note.getPitch();
+    if (pitch >= 1 && pitch <= 16 && note.getVelocity() > 0) {
+      selectChannelPattern(PACMAN_CHANNEL_LABEL, pitch - 1, "Pacman pad " + pitch);
       return;
     }
 
-    pacmanChannel.fader.setValue(1);
+    int greenPatternIndex = getGreenBankPatternIndex(note);
+    if (greenPatternIndex >= 0 && note.getVelocity() > 0) {
+      selectChannelPattern(
+          AUTOPLAY_CHANNEL_LABEL, greenPatternIndex, "green pad " + (greenPatternIndex + 1));
+    }
+  }
 
-    if (patternIndex >= pacmanChannel.patterns.size()) {
+  private int getGreenBankPatternIndex(MidiNoteOn note) {
+    if (note.getChannel() != GREEN_BANK_CHANNEL) {
+      return -1;
+    }
+
+    int pitch = note.getPitch();
+    if (pitch < 52 || pitch > 67) {
+      return -1;
+    }
+
+    int row = (67 - pitch) / 4;
+    int col = pitch % 4;
+    return row * 4 + col;
+  }
+
+  private void selectChannelPattern(String channelLabel, int patternIndex, String controlLabel) {
+    LXChannel channel = findChannel(channelLabel);
+    if (channel == null) {
+      TE.log("JP-Mini could not find channel named " + channelLabel);
+      return;
+    }
+
+    this.activeChannelLabel = channelLabel;
+    channel.fader.setValue(1);
+
+    if (patternIndex >= channel.patterns.size()) {
       TE.log(
-          "JP-Mini pad "
-              + (patternIndex + 1)
-              + " has no Pacman pattern; channel only has "
-              + pacmanChannel.patterns.size());
+          "JP-Mini "
+              + controlLabel
+              + " has no "
+              + channelLabel
+              + " pattern; channel only has "
+              + channel.patterns.size());
       return;
     }
 
-    LXPattern pattern = pacmanChannel.patterns.get(patternIndex);
-    pacmanChannel.goPatternIndex(patternIndex);
-    TE.log("JP-Mini selected Pacman pattern " + (patternIndex + 1) + ": " + pattern.getLabel());
+    LXPattern pattern = channel.patterns.get(patternIndex);
+    channel.goPatternIndex(patternIndex);
+    TE.log(
+        "JP-Mini selected "
+            + channelLabel
+            + " pattern "
+            + (patternIndex + 1)
+            + ": "
+            + pattern.getLabel());
   }
 
-  private LXChannel findPacmanChannel() {
+  private LXChannel findChannel(String channelLabel) {
     for (LXAbstractChannel channel : this.lx.engine.mixer.channels) {
-      if (channel instanceof LXChannel && PACMAN_CHANNEL_LABEL.equals(channel.getLabel())) {
+      if (channel instanceof LXChannel && channelLabel.equals(channel.getLabel())) {
         return (LXChannel) channel;
       }
     }
@@ -127,54 +162,59 @@ public class JPMini extends LXMidiSurface {
 
     switch (cc.getCC()) {
       case AUTOPLAY_ON_CC:
-        enablePacmanAutoplay();
+        enableActiveChannelAutoplay();
         break;
       case AUTOPLAY_OFF_CC:
-        disablePacmanAutoplay();
+        disableActiveChannelAutoplay();
         break;
-      case SOLO_PACMAN_CC:
-        soloPacmanChannel();
+      case SOLO_ACTIVE_CHANNEL_CC:
+        soloActiveChannel();
         break;
       default:
         break;
     }
   }
 
-  private void enablePacmanAutoplay() {
-    LXChannel pacmanChannel = findPacmanChannel();
-    if (pacmanChannel == null) {
-      TE.log("JP-Mini could not enable autoplay; no channel named " + PACMAN_CHANNEL_LABEL);
+  private void enableActiveChannelAutoplay() {
+    LXChannel channel = findChannel(this.activeChannelLabel);
+    if (channel == null) {
+      TE.log("JP-Mini could not enable autoplay; no channel named " + this.activeChannelLabel);
       return;
     }
 
-    pacmanChannel.fader.setValue(1);
-    pacmanChannel.patternEngine.autoCycleMode.setValue(AutoCycleMode.NEXT);
-    pacmanChannel.enableAutoCycle(AUTOPLAY_INTERVAL_SECONDS);
-    TE.log("JP-Mini enabled Pacman autoplay at " + AUTOPLAY_INTERVAL_SECONDS + "s");
+    channel.fader.setValue(1);
+    channel.patternEngine.autoCycleMode.setValue(AutoCycleMode.NEXT);
+    channel.enableAutoCycle(AUTOPLAY_INTERVAL_SECONDS);
+    TE.log(
+        "JP-Mini enabled "
+            + this.activeChannelLabel
+            + " autoplay at "
+            + AUTOPLAY_INTERVAL_SECONDS
+            + "s");
   }
 
-  private void disablePacmanAutoplay() {
-    LXChannel pacmanChannel = findPacmanChannel();
-    if (pacmanChannel == null) {
-      TE.log("JP-Mini could not disable autoplay; no channel named " + PACMAN_CHANNEL_LABEL);
+  private void disableActiveChannelAutoplay() {
+    LXChannel channel = findChannel(this.activeChannelLabel);
+    if (channel == null) {
+      TE.log("JP-Mini could not disable autoplay; no channel named " + this.activeChannelLabel);
       return;
     }
 
-    pacmanChannel.disableAutoCycle();
-    TE.log("JP-Mini disabled Pacman autoplay");
+    channel.disableAutoCycle();
+    TE.log("JP-Mini disabled " + this.activeChannelLabel + " autoplay");
   }
 
-  private void soloPacmanChannel() {
-    LXChannel pacmanChannel = findPacmanChannel();
-    if (pacmanChannel == null) {
-      TE.log("JP-Mini could not solo; no channel named " + PACMAN_CHANNEL_LABEL);
+  private void soloActiveChannel() {
+    LXChannel activeChannel = findChannel(this.activeChannelLabel);
+    if (activeChannel == null) {
+      TE.log("JP-Mini could not solo; no channel named " + this.activeChannelLabel);
       return;
     }
 
     for (LXAbstractChannel channel : this.lx.engine.mixer.channels) {
-      channel.fader.setValue(channel == pacmanChannel ? 1 : 0);
+      channel.fader.setValue(channel == activeChannel ? 1 : 0);
     }
-    TE.log("JP-Mini soloed Pacman channel");
+    TE.log("JP-Mini soloed " + this.activeChannelLabel + " channel");
   }
 
   @Override


### PR DESCRIPTION
## Summary
- Map the JP-Mini green 4x4 bank to the Autoplay channel patterns
- Keep pad presses layer-friendly by raising only the selected channel fader
- Make the shared top CC buttons act on the most recently selected JP-Mini bank/channel

## Verification
- Ran `./mvnw-te.sh -DskipTests package` successfully