### PR TITLE
Expand JP-Mini controller banks

### DIFF
--- a/te-app/src/main/java/titanicsend/lx/JPMini.java
+++ b/te-app/src/main/java/titanicsend/lx/JPMini.java
@@ -15,6 +15,8 @@ import heronarts.lx.mixer.LXAbstractChannel;
 import heronarts.lx.mixer.LXChannel;
 import heronarts.lx.mixer.LXPatternEngine.AutoCycleMode;
 import heronarts.lx.pattern.LXPattern;
+import java.util.HashSet;
+import java.util.Set;
 import titanicsend.midi.MidiNames;
 import titanicsend.util.TE;
 
@@ -29,17 +31,26 @@ import titanicsend.util.TE;
 @LXMidiSurface.DeviceName(MidiNames.JPMINI)
 public class JPMini extends LXMidiSurface {
 
-  private static final String PACMAN_CHANNEL_LABEL = "Pacman";
-  private static final String AUTOPLAY_CHANNEL_LABEL = "Autoplay";
+  private static final ChannelTarget PACMAN_CHANNEL = new ChannelTarget("Pacman");
+  private static final ChannelTarget AUTOPLAY_CHANNEL = new ChannelTarget("Autoplay");
+  private static final ChannelTarget HIGH_1_CHANNEL = new ChannelTarget("HIGH", 0, "HIGH 1");
+  private static final ChannelTarget HIGH_2_CHANNEL = new ChannelTarget("HIGH", 1, "HIGH 2");
+  private static final ChannelTarget LOW_1_CHANNEL = new ChannelTarget("LOW", 0, "LOW 1");
+  private static final ChannelTarget LOW_2_CHANNEL = new ChannelTarget("LOW", 1, "LOW 2");
+  private static final ChannelTarget OTHER_CHANNEL = new ChannelTarget("Other");
   private static final int GREEN_BANK_CHANNEL = 9;
+  private static final int WHITE_BANK_CHANNEL = 9;
   private static final int TOP_BUTTON_CHANNEL = 0;
   private static final int AUTOPLAY_ON_CC = 22;
   private static final int AUTOPLAY_OFF_CC = 23;
   private static final int SOLO_ACTIVE_CHANNEL_CC = 24;
   private static final int TOP_BUTTON_TRIGGER_VALUE = 127;
   private static final double AUTOPLAY_INTERVAL_SECONDS = 30;
+  private static final double MASTER_BRIGHTNESS_STEP = 0.10;
+  private static final boolean LOG_RAW_MIDI_MESSAGES = false;
 
-  private String activeChannelLabel = PACMAN_CHANNEL_LABEL;
+  private final Set<String> steppedChannels = new HashSet<>();
+  private ChannelTarget activeChannel = PACMAN_CHANNEL;
 
   public JPMini(LX lx, LXMidiInput input, LXMidiOutput output) {
     super(lx, input, output);
@@ -58,8 +69,8 @@ public class JPMini extends LXMidiSurface {
 
   @Override
   public void noteOnReceived(MidiNoteOn note) {
-    TE.log(
-        "JP-Mini note on channel="
+    logRawMidi(
+        "note on channel="
             + note.getChannel()
             + " pitch="
             + note.getPitch()
@@ -68,14 +79,19 @@ public class JPMini extends LXMidiSurface {
 
     int pitch = note.getPitch();
     if (pitch >= 1 && pitch <= 16 && note.getVelocity() > 0) {
-      selectChannelPattern(PACMAN_CHANNEL_LABEL, pitch - 1, "Pacman pad " + pitch);
+      selectChannelPattern(PACMAN_CHANNEL, pitch - 1, "Pacman pad " + pitch);
       return;
     }
 
     int greenPatternIndex = getGreenBankPatternIndex(note);
     if (greenPatternIndex >= 0 && note.getVelocity() > 0) {
       selectChannelPattern(
-          AUTOPLAY_CHANNEL_LABEL, greenPatternIndex, "green pad " + (greenPatternIndex + 1));
+          AUTOPLAY_CHANNEL, greenPatternIndex, "green pad " + (greenPatternIndex + 1));
+      return;
+    }
+
+    if (note.getVelocity() > 0 && handleWhiteBankPad(note)) {
+      return;
     }
   }
 
@@ -94,14 +110,74 @@ public class JPMini extends LXMidiSurface {
     return row * 4 + col;
   }
 
-  private void selectChannelPattern(String channelLabel, int patternIndex, String controlLabel) {
-    LXChannel channel = findChannel(channelLabel);
+  private boolean handleWhiteBankPad(MidiNoteOn note) {
+    if (note.getChannel() != WHITE_BANK_CHANNEL) {
+      return false;
+    }
+
+    switch (note.getPitch()) {
+      case 80:
+        setMasterBrightness(0.25, "white pad master 25 percent");
+        return true;
+      case 81:
+        setMasterBrightness(0.50, "white pad master 50 percent");
+        return true;
+      case 82:
+        setMasterBrightness(0.75, "white pad master 75 percent");
+        return true;
+      case 83:
+        setMasterBrightness(1.00, "white pad master 100 percent");
+        return true;
+      case 76:
+        stepChannelPattern(HIGH_1_CHANNEL, -1);
+        return true;
+      case 77:
+        stepChannelPattern(HIGH_1_CHANNEL, 1);
+        return true;
+      case 78:
+        stepChannelPattern(HIGH_2_CHANNEL, -1);
+        return true;
+      case 79:
+        stepChannelPattern(HIGH_2_CHANNEL, 1);
+        return true;
+      case 72:
+        stepChannelPattern(LOW_1_CHANNEL, -1);
+        return true;
+      case 73:
+        stepChannelPattern(LOW_1_CHANNEL, 1);
+        return true;
+      case 74:
+        stepChannelPattern(LOW_2_CHANNEL, -1);
+        return true;
+      case 75:
+        stepChannelPattern(LOW_2_CHANNEL, 1);
+        return true;
+      case 68:
+        stepChannelPattern(OTHER_CHANNEL, -1);
+        return true;
+      case 69:
+        stepChannelPattern(OTHER_CHANNEL, 1);
+        return true;
+      case 70:
+        nudgeMasterBrightness(-MASTER_BRIGHTNESS_STEP);
+        return true;
+      case 71:
+        nudgeMasterBrightness(MASTER_BRIGHTNESS_STEP);
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  private void selectChannelPattern(ChannelTarget target, int patternIndex, String controlLabel) {
+    LXChannel channel = findChannel(target);
     if (channel == null) {
-      TE.log("JP-Mini could not find channel named " + channelLabel);
+      TE.log("JP-Mini could not find channel " + target.displayLabel);
       return;
     }
 
-    this.activeChannelLabel = channelLabel;
+    this.activeChannel = target;
+    this.steppedChannels.add(target.key());
     channel.fader.setValue(1);
 
     if (patternIndex >= channel.patterns.size()) {
@@ -109,7 +185,7 @@ public class JPMini extends LXMidiSurface {
           "JP-Mini "
               + controlLabel
               + " has no "
-              + channelLabel
+              + target.displayLabel
               + " pattern; channel only has "
               + channel.patterns.size());
       return;
@@ -119,17 +195,73 @@ public class JPMini extends LXMidiSurface {
     channel.goPatternIndex(patternIndex);
     TE.log(
         "JP-Mini selected "
-            + channelLabel
+            + target.displayLabel
             + " pattern "
             + (patternIndex + 1)
             + ": "
             + pattern.getLabel());
   }
 
-  private LXChannel findChannel(String channelLabel) {
+  private void stepChannelPattern(ChannelTarget target, int direction) {
+    LXChannel channel = findChannel(target);
+    if (channel == null) {
+      TE.log("JP-Mini could not find channel " + target.displayLabel);
+      return;
+    }
+
+    this.activeChannel = target;
+    channel.fader.setValue(1);
+
+    if (channel.patterns.isEmpty()) {
+      TE.log("JP-Mini could not step " + target.displayLabel + "; channel has no patterns");
+      return;
+    }
+
+    int nextIndex;
+    if (!this.steppedChannels.contains(target.key())) {
+      nextIndex = 0;
+      this.steppedChannels.add(target.key());
+    } else {
+      int activeIndex = channel.getActivePatternIndex();
+      nextIndex = Math.floorMod(activeIndex + direction, channel.patterns.size());
+    }
+
+    LXPattern pattern = channel.patterns.get(nextIndex);
+    channel.goPatternIndex(nextIndex);
+    TE.log(
+        "JP-Mini selected "
+            + target.displayLabel
+            + " pattern "
+            + (nextIndex + 1)
+            + ": "
+            + pattern.getLabel());
+  }
+
+  private void setMasterBrightness(double value, String controlLabel) {
+    double constrained = Math.max(0, Math.min(1, value));
+    this.lx.engine.mixer.masterBus.fader.setValue(constrained);
+    this.activeChannel = PACMAN_CHANNEL;
+    TE.log(
+        "JP-Mini set master brightness to "
+            + Math.round(constrained * 100)
+            + " percent via "
+            + controlLabel);
+  }
+
+  private void nudgeMasterBrightness(double delta) {
+    double current = this.lx.engine.mixer.masterBus.fader.getValue();
+    setMasterBrightness(
+        current + delta, delta > 0 ? "white pad master up" : "white pad master down");
+  }
+
+  private LXChannel findChannel(ChannelTarget target) {
+    int match = 0;
     for (LXAbstractChannel channel : this.lx.engine.mixer.channels) {
-      if (channel instanceof LXChannel && channelLabel.equals(channel.getLabel())) {
-        return (LXChannel) channel;
+      if (channel instanceof LXChannel && target.label.equals(channel.getLabel())) {
+        if (match == target.occurrence) {
+          return (LXChannel) channel;
+        }
+        match++;
       }
     }
     return null;
@@ -137,8 +269,8 @@ public class JPMini extends LXMidiSurface {
 
   @Override
   public void noteOffReceived(MidiNote note) {
-    TE.log(
-        "JP-Mini note off channel="
+    logRawMidi(
+        "note off channel="
             + note.getChannel()
             + " pitch="
             + note.getPitch()
@@ -148,8 +280,8 @@ public class JPMini extends LXMidiSurface {
 
   @Override
   public void controlChangeReceived(MidiControlChange cc) {
-    TE.log(
-        "JP-Mini CC channel="
+    logRawMidi(
+        "CC channel="
             + cc.getChannel()
             + " cc="
             + cc.getCC()
@@ -176,9 +308,9 @@ public class JPMini extends LXMidiSurface {
   }
 
   private void enableActiveChannelAutoplay() {
-    LXChannel channel = findChannel(this.activeChannelLabel);
+    LXChannel channel = findChannel(this.activeChannel);
     if (channel == null) {
-      TE.log("JP-Mini could not enable autoplay; no channel named " + this.activeChannelLabel);
+      TE.log("JP-Mini could not enable autoplay; no channel " + this.activeChannel.displayLabel);
       return;
     }
 
@@ -187,49 +319,65 @@ public class JPMini extends LXMidiSurface {
     channel.enableAutoCycle(AUTOPLAY_INTERVAL_SECONDS);
     TE.log(
         "JP-Mini enabled "
-            + this.activeChannelLabel
+            + this.activeChannel.displayLabel
             + " autoplay at "
             + AUTOPLAY_INTERVAL_SECONDS
             + "s");
   }
 
   private void disableActiveChannelAutoplay() {
-    LXChannel channel = findChannel(this.activeChannelLabel);
+    LXChannel channel = findChannel(this.activeChannel);
     if (channel == null) {
-      TE.log("JP-Mini could not disable autoplay; no channel named " + this.activeChannelLabel);
+      TE.log("JP-Mini could not disable autoplay; no channel " + this.activeChannel.displayLabel);
       return;
     }
 
     channel.disableAutoCycle();
-    TE.log("JP-Mini disabled " + this.activeChannelLabel + " autoplay");
+    TE.log("JP-Mini disabled " + this.activeChannel.displayLabel + " autoplay");
   }
 
   private void soloActiveChannel() {
-    LXChannel activeChannel = findChannel(this.activeChannelLabel);
-    if (activeChannel == null) {
-      TE.log("JP-Mini could not solo; no channel named " + this.activeChannelLabel);
+    LXChannel channelToSolo = findChannel(this.activeChannel);
+    if (channelToSolo == null) {
+      TE.log("JP-Mini could not solo; no channel " + this.activeChannel.displayLabel);
       return;
     }
 
     for (LXAbstractChannel channel : this.lx.engine.mixer.channels) {
-      channel.fader.setValue(channel == activeChannel ? 1 : 0);
+      channel.fader.setValue(channel == channelToSolo ? 1 : 0);
     }
-    TE.log("JP-Mini soloed " + this.activeChannelLabel + " channel");
+    TE.log("JP-Mini soloed " + this.activeChannel.displayLabel + " channel");
+  }
+
+  private static class ChannelTarget {
+    private final String label;
+    private final int occurrence;
+    private final String displayLabel;
+
+    private ChannelTarget(String label) {
+      this(label, 0, label);
+    }
+
+    private ChannelTarget(String label, int occurrence, String displayLabel) {
+      this.label = label;
+      this.occurrence = occurrence;
+      this.displayLabel = displayLabel;
+    }
+
+    private String key() {
+      return this.label + "#" + this.occurrence;
+    }
   }
 
   @Override
   public void programChangeReceived(MidiProgramChange pc) {
-    TE.log(
-        "JP-Mini program change channel="
-            + pc.getChannel()
-            + " program="
-            + pc.getProgram());
+    logRawMidi("program change channel=" + pc.getChannel() + " program=" + pc.getProgram());
   }
 
   @Override
   public void pitchBendReceived(MidiPitchBend pitchBend) {
-    TE.log(
-        "JP-Mini pitch bend channel="
+    logRawMidi(
+        "pitch bend channel="
             + pitchBend.getChannel()
             + " bend="
             + pitchBend.getPitchBend()
@@ -239,8 +387,8 @@ public class JPMini extends LXMidiSurface {
 
   @Override
   public void aftertouchReceived(MidiAftertouch aftertouch) {
-    TE.log(
-        "JP-Mini aftertouch channel="
+    logRawMidi(
+        "aftertouch channel="
             + aftertouch.getChannel()
             + " pressure="
             + aftertouch.getAftertouch());
@@ -248,11 +396,17 @@ public class JPMini extends LXMidiSurface {
 
   @Override
   public void midiPanicReceived() {
-    TE.log("JP-Mini MIDI panic received");
+    logRawMidi("MIDI panic received");
   }
 
   @Override
   public void sysexReceived(LXSysexMessage sysex) {
-    TE.log("JP-Mini sysex " + sysex);
+    logRawMidi("sysex " + sysex);
+  }
+
+  private void logRawMidi(String message) {
+    if (LOG_RAW_MIDI_MESSAGES) {
+      TE.log("JP-Mini " + message);
+    }
   }
 }


### PR DESCRIPTION
## Summary
- Add JP-Mini white-bank controls for master brightness, HIGH/LOW/Other pattern stepping, and active-channel top-button controls
- Preserve Pacman and Autoplay bank behavior while allowing layered playback
- Keep raw JP-Mini MIDI logs available behind a disabled debug switch

## Verification
- `./mvnw-te.sh -DskipTests package`
