### PR TITLE
Reduce JP-Mini brightness step

### DIFF
--- a/te-app/src/main/java/titanicsend/lx/JPMini.java
+++ b/te-app/src/main/java/titanicsend/lx/JPMini.java
@@ -46,7 +46,7 @@ public class JPMini extends LXMidiSurface {
   private static final int SOLO_ACTIVE_CHANNEL_CC = 24;
   private static final int TOP_BUTTON_TRIGGER_VALUE = 127;
   private static final double AUTOPLAY_INTERVAL_SECONDS = 30;
-  private static final double MASTER_BRIGHTNESS_STEP = 0.10;
+  private static final double MASTER_BRIGHTNESS_STEP = 0.05;
   private static final boolean LOG_RAW_MIDI_MESSAGES = false;
 
   private final Set<String> steppedChannels = new HashSet<>();


### PR DESCRIPTION
## Summary
- Change the JP-Mini white-bank master brightness up/down buttons from 10% steps to 5% steps

## Verification
- `./mvnw-te.sh -DskipTests package`
